### PR TITLE
fix: Fix code scanning alert no. 1: Replacement of a substring with itself

### DIFF
--- a/src/clientModules/Metadata.tsx
+++ b/src/clientModules/Metadata.tsx
@@ -31,7 +31,7 @@ const Metadata: React.FC = () => {
                     year: 'numeric',
                     month: '2-digit',
                     day: '2-digit',
-                }).replace(/\//g, '/');
+                });
             }
         }
 


### PR DESCRIPTION
Fixes [https://github.com/MSDocsCHS/website/security/code-scanning/1](https://github.com/MSDocsCHS/website/security/code-scanning/1)

To fix the problem, we need to ensure that the date format conversion is meaningful. The current replacement operation is redundant because it replaces each forward slash with itself. Instead, we should ensure that the date format is correctly converted to the desired format without unnecessary operations.

- We will remove the redundant replacement operation on line 34.
- This change will be made in the file `src/clientModules/Metadata.tsx`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
