### PR TITLE
Fix code scanning alert no. 2: Inefficient regular expression

### DIFF
--- a/src/components/CustomLink.tsx
+++ b/src/components/CustomLink.tsx
@@ -3,7 +3,6 @@ import Link from '@docusaurus/Link';
 
 export const CustomLink = (props) => {
   const href = props.href || '';
-  // 修改正则表达式，排除 http 和 https 协议
   const customSchemeRegex = /^(?!https?:)[a-z]+(?:[-+.][a-z0-9]+)*:/i;
   const isCustomScheme = customSchemeRegex.test(href);
 

--- a/src/components/CustomLink.tsx
+++ b/src/components/CustomLink.tsx
@@ -4,7 +4,7 @@ import Link from '@docusaurus/Link';
 export const CustomLink = (props) => {
   const href = props.href || '';
   // 修改正则表达式，排除 http 和 https 协议
-  const customSchemeRegex = /^(?!https?:)[a-z]+([-+.]?[a-z0-9]+)*:/i;
+  const customSchemeRegex = /^(?!https?:)[a-z]+(?:[-+.][a-z0-9]+)*:/i;
   const isCustomScheme = customSchemeRegex.test(href);
 
   if (isCustomScheme) {


### PR DESCRIPTION
Fixes [https://github.com/MSDocsCHS/website/security/code-scanning/2](https://github.com/MSDocsCHS/website/security/code-scanning/2)

To fix the problem, we need to modify the regular expression to remove the ambiguity that causes exponential backtracking. Specifically, we can replace the `[a-z0-9]+` part with a more precise pattern that avoids the problematic repetition.

- We will change the regular expression to use a non-capturing group and a more specific character class to avoid ambiguity.
- The updated regular expression will be `^(?!https?:)[a-z]+(?:[-+.][a-z0-9]+)*:`, which ensures that the repetition is not ambiguous and prevents exponential backtracking.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
